### PR TITLE
Typo fix in workspace help

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -92,7 +92,7 @@ const COLUMNS: &[&[Section]] = &[
                     Schema::Hardcoded(&["Super", "Shift", "↓"]),
                 ),
                 Shortcut::new(
-                    "Switch focus to the worksapce above",
+                    "Switch focus to the workspace above",
                     Event::MoveWorkspaceAbove,
                     Schema::Hardcoded(&["Super", "Ctrl", "↑"]),
                 ),


### PR DESCRIPTION
I noticed a typo in the shortcuts guide. This PR fixes it. 

Typo in action:
![image](https://user-images.githubusercontent.com/50179998/80810621-42c64e80-8b92-11ea-8327-f3575aec4992.png)
