### PR TITLE
Add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ This will generate the `pop-shell-shortcuts` executable in the `target/debug` di
 Install with `make`.
 
 ```sh
-make install prefix=/usr
+make install
 ```
 
 Alternatively, the debug version can be installed.
 
 ```sh
-make install prefix=/usr DEBUG=1
+make install DEBUG=1
 ```
 
 An `uninstall` target is also provided to remove the installed application.

--- a/README.md
+++ b/README.md
@@ -54,19 +54,19 @@ This will generate the `pop-shell-shortcuts` executable in the `target/debug` di
 Install with `make`.
 
 ```sh
-make install
+sudo make install
 ```
 
 Alternatively, the debug version can be installed.
 
 ```sh
-make install DEBUG=1
+sudo make install DEBUG=1
 ```
 
 An `uninstall` target is also provided to remove the installed application.
 
 ```sh
-make uninstall
+sudo make uninstall
 ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -3,3 +3,78 @@
 Application for displaying and demoing Pop Shell shortcuts.
 
 ![](screenshot.png)
+
+## Dependencies
+
+The following dependencies are required to build `shell-extensions`.
+
+* [cargo](https://packages.debian.org/stable/rust/cargo)
+* [rustc](https://packages.debian.org/stable/rust/rustc)
+* [libgtk-3-dev](https://packages.debian.org/stable/libdevel/libgtk-3-dev)
+
+On a debian-derived distribution, the required dependencies are easily installed with `apt`.
+
+```sh
+apt install cargo libgtk-3-dev rustc
+```
+
+## Build
+
+First, get the project's source code.
+
+```sh
+git clone https://github.com/pop-os/shell-shortcuts.git
+```
+
+The following `make` commands are run from the top-level of the source directory, so move to that directory.
+
+```sh
+cd shell-shortcuts
+```
+
+The project's sources are built with `make`.
+
+```sh
+make
+```
+
+Assuming nothing goes wrong, this will generate the `pop-shell-shortcuts` executable in the `target/release` directory.
+
+By default, the application is built for release.
+To build the binary with debug symbols, provide `DEBUG=1` with the `make` command.
+
+```sh
+make DEBUG=1
+```
+
+This will generate the `pop-shell-shortcuts` executable in the `target/debug` directory.
+
+## Install
+
+Install with `make`.
+
+```sh
+make install prefix=/usr
+```
+
+Alternatively, the debug version can be installed.
+
+```sh
+make install prefix=/usr DEBUG=1
+```
+
+An `uninstall` target is also provided to remove the installed application.
+
+```sh
+make uninstall
+```
+
+## Run
+
+Execute the `pop-shell-shortcuts` binary.
+Assuming the binary has been installed in your path, run it as usual.
+
+```sh
+pop-shell-shortcuts
+```
+

--- a/README.md
+++ b/README.md
@@ -77,4 +77,3 @@ Assuming the binary has been installed in your path, run it as usual.
 ```sh
 pop-shell-shortcuts
 ```
-


### PR DESCRIPTION
Fixes #6

This PR adds build instructions to the README.
Specifically, it adds instructions for installing dependencies, and building, installing, and running `shell-shortcuts`.
This should make it easier for anyone wanting to build the application in the future.

I'm happy to make any changes to the formatting or organization, just let me know.