### PR TITLE
fix(window): Set size_request for window to 600x350

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -269,7 +269,8 @@ pub fn main(app: &gtk::Application) {
 
     let window = cascade! {
         gtk::ApplicationWindow::new(app);
-        ..set_size_request(600, 500);
+        ..set_size_request(600, 350);
+        ..set_default_size(600, 500);
         ..set_icon_name("input-keyboard".into());
         ..add(&content);
         ..show_all();


### PR DESCRIPTION
This will reduce the minimum vertical height of the window, allowing it to shrink more in
tiled usage. Additionally, it adds a set_default_size() to 600x500 (the previous
minimum size) so that it starts at the same size as before.

Fixes #21